### PR TITLE
Added delete User Route

### DIFF
--- a/backend/routes/auth/auth.js
+++ b/backend/routes/auth/auth.js
@@ -4,6 +4,7 @@ import signup from "./signup.js";
 import login from "./login.js";
 import changePassword from "./changePassword.js";
 import getUser from "./getUser.js";
+import deleteUser from "./deleteUser.js";
 
 const router = express.Router();
 
@@ -44,9 +45,19 @@ router.post("/getuser", async (req,res) => {
         const { resStatus, resMessage } = await getUser(req);
         res.status(resStatus).json(resMessage);
     }catch(err){
-        console.log("GetUser error: ",err);
+		console.log("GetUser error: ",err);
         res.status(500).json({success:false,message:'Internal Server error.'})
     }
 });
+
+router.delete("/deleteUser",async (req,res)=>{
+	try{
+		const { resStatus, resMessage } = await deleteUser(req);
+		res.status(resStatus).json(resMessage);
+	}catch(err){
+		console.log("User Deletion Failed: ",err);
+		res.status(500).json({success:false,message:'Internal Server error.'})
+	}
+})
 
 export default router;

--- a/backend/routes/auth/deleteUser.js
+++ b/backend/routes/auth/deleteUser.js
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import User from "../../models/User.js";
+
+export default async function deleteUser(req) {
+	try {
+		// Zod validation
+		const deleteUserSchema = z.object({
+			email: z.string().email("Invalid email address"),
+			password: z.string().min(1, "Password is required"),
+		});
+		const parseResult = deleteUserSchema.safeParse(req.body);
+		if (!parseResult.success) {
+			return {
+				resStatus: 400,
+				resMessage: {
+					message: JSON.parse(parseResult.error)
+						.map((err) => err.message)
+						.join(", "),
+				},
+			};
+		}
+
+		const { email, password } = parseResult.data;
+		// check if user exists and is given the correct password
+		const user = await User.findOne({ email: email });
+		if (!user) {
+			return {
+				resStatus: 400,
+				resMessage: {
+					message: "User Not Exist",
+				},
+			};
+		}
+
+		const passMatch = await bcrypt.compare(password.trim(), user.password);
+
+		if (!passMatch) {
+			return {
+				resStatus: 400,
+				resMessage: {
+					message: "password Doesn't Match",
+				},
+			};
+		}
+
+		await user.deleteOne();
+
+		return {
+			resStatus: 200,
+			resMessage: {
+				message: "Account deleted Succesfully",
+			},
+		};
+	} catch (err) {
+		console.log(err);
+		return {
+			resStatus: 500,
+			resMessage: {
+				message: "Internal server error",
+			},
+		};
+	}
+}


### PR DESCRIPTION
fixes #21 
# Add `DELETE /api/auth/deleteUser` route

## Summary
This PR introduces a new endpoint to allow users to delete their account by providing their email and password. It includes validation, password verification, and safe deletion using Mongoose.

## Changes
- Added `router.delete("/deleteUser")` in `auth.js`.
- Created `deleteUser.js` handler:
  - Validates `{ email, password }` with Zod.
  - Checks user existence.
  - Verifies password with bcrypt.
  - Deletes user document and returns status messages.

## Example
**Request**
```http
DELETE /api/auth/deleteUser
Content-Type: application/json

{
  "email": "user@example.com",
  "password": "password123"
}
