### PR TITLE
Implemented Dark Mode / Theme Toggle button closes #29

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/icons-material": "^7.3.2",
+        "@mui/icons-material": "^7.3.4",
         "@mui/lab": "^7.0.0-beta.17",
         "@mui/material": "^7.3.2",
         "@testing-library/dom": "^10.4.1",
@@ -3118,9 +3118,9 @@
       "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.2.tgz",
-      "integrity": "sha512-AOyfHjyDKVPGJJFtxOlept3EYEdLoar/RvssBTWVAvDJGIE676dLi2oT/Kx+FoVXFoA/JdV7DEMq/BVWV3KHRw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.4.tgz",
+      "integrity": "sha512-BIktMapG3r4iXwIhYNpvk97ZfYWTreBBQTWjQKbNbzI64+ULHfYavQEX2w99aSWHS58DvXESWIgbD9adKcUOBw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3128,12 +3128,12 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.2.tgz",
-      "integrity": "sha512-TZWazBjWXBjR6iGcNkbKklnwodcwj0SrChCNHc9BhD9rBgET22J1eFhHsEmvSvru9+opDy3umqAimQjokhfJlQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.4.tgz",
+      "integrity": "sha512-9n6Xcq7molXWYb680N2Qx+FRW8oT6j/LXF5PZFH3ph9X/Rct0B/BlLAsFI7iL9ySI6LVLuQIVtrLiPT82R7OZw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.3"
+        "@babel/runtime": "^7.28.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3143,7 +3143,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^7.3.2",
+        "@mui/material": "^7.3.4",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -3198,16 +3198,16 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.2.tgz",
-      "integrity": "sha512-qXvbnawQhqUVfH1LMgMaiytP+ZpGoYhnGl7yYq2x57GYzcFL/iPzSZ3L30tlbwEjSVKNYcbiKO8tANR1tadjUg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
+      "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.3",
-        "@mui/core-downloads-tracker": "^7.3.2",
-        "@mui/system": "^7.3.2",
-        "@mui/types": "^7.4.6",
-        "@mui/utils": "^7.3.2",
+        "@babel/runtime": "^7.28.4",
+        "@mui/core-downloads-tracker": "^7.3.4",
+        "@mui/system": "^7.3.3",
+        "@mui/types": "^7.4.7",
+        "@mui/utils": "^7.3.3",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -3226,7 +3226,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.2",
+        "@mui/material-pigment-css": "^7.3.3",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3253,13 +3253,13 @@
       "license": "MIT"
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.2.tgz",
-      "integrity": "sha512-ha7mFoOyZGJr75xeiO9lugS3joRROjc8tG1u4P50dH0KR7bwhHznVMcYg7MouochUy0OxooJm/OOSpJ7gKcMvg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.3.tgz",
+      "integrity": "sha512-OJM+9nj5JIyPUvsZ5ZjaeC9PfktmK+W5YaVLToLR8L0lB/DGmv1gcKE43ssNLSvpoW71Hct0necfade6+kW3zQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.3",
-        "@mui/utils": "^7.3.2",
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3280,12 +3280,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.2.tgz",
-      "integrity": "sha512-PkJzW+mTaek4e0nPYZ6qLnW5RGa0KN+eRTf5FA2nc7cFZTeM+qebmGibaTLrgQBy3UpcpemaqfzToBNkzuxqew==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.3.tgz",
+      "integrity": "sha512-CmFxvRJIBCEaWdilhXMw/5wFJ1+FT9f3xt+m2pPXhHPeVIbBg9MnMvNSJjdALvnQJMPw8jLhrUtXmN7QAZV2fw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.3",
+        "@babel/runtime": "^7.28.4",
         "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -3314,16 +3314,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.2.tgz",
-      "integrity": "sha512-9d8JEvZW+H6cVkaZ+FK56R53vkJe3HsTpcjMUtH8v1xK6Y1TjzHdZ7Jck02mGXJsE6MQGWVs3ogRHTQmS9Q/rA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.3.tgz",
+      "integrity": "sha512-Lqq3emZr5IzRLKaHPuMaLBDVaGvxoh6z7HMWd1RPKawBM5uMRaQ4ImsmmgXWtwJdfZux5eugfDhXJUo2mliS8Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.3",
-        "@mui/private-theming": "^7.3.2",
-        "@mui/styled-engine": "^7.3.2",
-        "@mui/types": "^7.4.6",
-        "@mui/utils": "^7.3.2",
+        "@babel/runtime": "^7.28.4",
+        "@mui/private-theming": "^7.3.3",
+        "@mui/styled-engine": "^7.3.3",
+        "@mui/types": "^7.4.7",
+        "@mui/utils": "^7.3.3",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -3354,12 +3354,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.6.tgz",
-      "integrity": "sha512-NVBbIw+4CDMMppNamVxyTccNv0WxtDb7motWDlMeSC8Oy95saj1TIZMGynPpFLePt3yOD8TskzumeqORCgRGWw==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.7.tgz",
+      "integrity": "sha512-8vVje9rdEr1rY8oIkYgP+Su5Kwl6ik7O3jQ0wl78JGSmiZhRHV+vkjooGdKD8pbtZbutXFVTWQYshu2b3sG9zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.3"
+        "@babel/runtime": "^7.28.4"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3371,13 +3371,13 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.2.tgz",
-      "integrity": "sha512-4DMWQGenOdLnM3y/SdFQFwKsCLM+mqxzvoWp9+x2XdEzXapkznauHLiXtSohHs/mc0+5/9UACt1GdugCX2te5g==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.3.tgz",
+      "integrity": "sha512-kwNAUh7bLZ7mRz9JZ+6qfRnnxbE4Zuc+RzXnhSpRSxjTlSTj7b4JxRLXpG+MVtPVtqks5k/XC8No1Vs3x4Z2gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.3",
-        "@mui/types": "^7.4.6",
+        "@babel/runtime": "^7.28.4",
+        "@mui/types": "^7.4.7",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/icons-material": "^7.3.2",
+    "@mui/icons-material": "^7.3.4",
     "@mui/lab": "^7.0.0-beta.17",
     "@mui/material": "^7.3.2",
     "@testing-library/dom": "^10.4.1",

--- a/frontend/src/components/ui/ThemeContext.jsx
+++ b/frontend/src/components/ui/ThemeContext.jsx
@@ -1,0 +1,139 @@
+import React, { createContext, useState, useMemo, useContext } from 'react';
+import { createTheme, ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+import { CssBaseline, IconButton } from '@mui/material';
+// import { Brightness4, Brightness7 } from '@mui/icons-material';
+import { WbSunny, Brightness4 } from '@mui/icons-material';
+
+export const ColorModeContext = createContext({ 
+    toggleColorMode: () => {}, 
+    mode: 'light' 
+});
+
+export const useThemeContext = () => useContext(ColorModeContext);
+
+const getDesignTokens = (mode) => ({
+    palette: {
+        mode,
+        ...(mode === 'light'
+            ? {
+                // Light Mode Palette
+                primary: {
+                    main: '#1976D2', 
+                    light: '#42a5f5',
+                    dark: '#1565c0',
+                    contrastText: '#fff',
+                },
+                secondary: {
+                    main: '#9c27b0', 
+                },
+                background: {
+                    default: '#F5F7FA', // Consistent light background
+                    paper: '#FFFFFF', // Consistent white card background
+                },
+                text: {
+                    primary: '#1F2937', 
+                    secondary: '#4B5563', 
+                },
+            }
+            : {
+                // Dark Mode Palette
+                primary: {
+                    main: '#90CAF9', 
+                    light: '#e3f2fd',
+                    dark: '#42a5f5',
+                    contrastText: '#000',
+                },
+                secondary: {
+                    main: '#CE93D8', 
+                },
+                background: {
+                    default: '#121212', // Consistent dark background
+                    paper: '#1E1E1E', // Consistent dark card background
+                },
+                text: {
+                    primary: '#FFFFFF', 
+                    secondary: '#B0B0B0', 
+                },
+            }),
+    },
+    shape: {
+        borderRadius: 12, // Inherit from your original theme setting
+    },
+    typography: {
+        fontFamily: 'Inter, sans-serif', 
+    },
+});
+
+export function ThemeContextProvider({ children }) {
+    const [mode, setMode] = useState(() => {
+        const storedMode = localStorage.getItem('themeMode');
+        if (storedMode) return storedMode;
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    });
+
+    const colorMode = useMemo(
+        () => ({
+            toggleColorMode: () => {
+                setMode((prevMode) => {
+                    const newMode = prevMode === 'light' ? 'dark' : 'light';
+                    localStorage.setItem('themeMode', newMode);
+                    return newMode;
+                });
+            },
+            mode,
+        }),
+        [mode],
+    );
+
+    const theme = useMemo(() => createTheme(getDesignTokens(mode)), [mode]);
+
+    return (
+        <ColorModeContext.Provider value={colorMode}>
+            {/* APPLY MuiThemeProvider HERE to make the dynamic theme available */}
+            <MuiThemeProvider theme={theme}>
+                {/* CssBaseline must be inside the MuiThemeProvider */}
+                <CssBaseline />
+                {children}
+            </MuiThemeProvider>
+        </ColorModeContext.Provider>
+    );
+}
+
+export function ThemeToggleButton() {
+    const { mode, toggleColorMode } = useThemeContext();
+
+    const theme = createTheme(getDesignTokens(mode));
+    const buttonColor = theme.palette.mode === 'dark' 
+        ? theme.palette.primary.light 
+        : theme.palette.primary.dark;
+
+    return (
+        <IconButton
+            sx={{
+                ml: 1,
+                bgcolor: mode === 'dark' ? 'rgba(40,40,40,0.85)' : 'rgba(230,240,255,0.9)', // soft blue/gray for light, subtle dark for dark
+                color: mode === 'dark' ? '#fff' : '#1976d2', // white icon in dark mode, primary blue in light
+                border: '1.5px solid',
+                borderColor: mode === 'dark' ? '#444' : '#e0e0e0',
+                boxShadow: mode === 'dark' ? 0 : 2,
+                backdropFilter: 'blur(2px)',
+                transition: 'background 0.2s, color 0.2s',
+                '&:hover': {
+                    bgcolor: mode === 'dark'
+                        ? 'rgba(70,70,70,1)'
+                        : 'rgba(180,210,255,0.4)',
+                    color: mode === 'dark'
+                        ? '#ffe082' // pale yellow accent on hover for dark
+                        : '#135ca3', // darker blue accent for light
+                }
+            }}
+            onClick={toggleColorMode}
+            aria-label={`Switch to ${mode === 'dark' ? 'light' : 'dark'} mode`}
+        >
+            {mode === 'light'
+                ? <Brightness4 fontSize="medium" /> // moon icon for dark
+                : <WbSunny fontSize="medium" /> // sun icon for light
+            }
+        </IconButton>
+    );
+}

--- a/frontend/src/components/ui/headerbar.jsx
+++ b/frontend/src/components/ui/headerbar.jsx
@@ -4,6 +4,7 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import NewPagePopup from './newPagePopup';
+import { ThemeToggleButton } from "./ThemeContext";
 
 export default function HeaderBar({ onLogout, onNewPage }) {
     const [open, setOpen] = React.useState(false);
@@ -26,6 +27,8 @@ export default function HeaderBar({ onLogout, onNewPage }) {
                     <Button color="inherit" onClick={onLogout}>
                         Logout
                     </Button>
+                    <ThemeToggleButton />
+
                 </Toolbar>
             </AppBar>
 

--- a/frontend/src/components/ui/provider.jsx
+++ b/frontend/src/components/ui/provider.jsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
+import { ThemeContextProvider } from "./ThemeContext";
 
 const theme = createTheme({
     palette: {
@@ -19,9 +20,8 @@ const theme = createTheme({
 
 export const UIProvider = ({ children }) => {
     return (
-        <ThemeProvider theme={theme}>
-            <CssBaseline />
+        <ThemeContextProvider>
             {children}
-        </ThemeProvider>
+        </ThemeContextProvider>
     );
 };

--- a/frontend/src/pages/home.jsx
+++ b/frontend/src/pages/home.jsx
@@ -4,6 +4,8 @@ import Sidebar from "../components/ui/sidebar";
 import HeaderBar from "../components/ui/headerbar";
 import PageView from "../components/ui/pageView";
 import { Typography } from "@mui/material";
+import { ThemeToggleButton } from "../components/ui/ThemeContext";
+
 
 export default function Home() {
     const navigate = useNavigate();

--- a/frontend/src/pages/landingpage.jsx
+++ b/frontend/src/pages/landingpage.jsx
@@ -25,6 +25,8 @@ import {
     GitHub as GitHubIcon
 } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
+import { ThemeToggleButton } from "../components/ui/ThemeContext";
+
 
 export default function Landing() {
     const navigate = useNavigate();
@@ -102,6 +104,11 @@ export default function Landing() {
         <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
             {/* Hero Section */}
             <Container maxWidth="lg" sx={{ py: 8 }}>
+                <Box sx={{ position: "absolute", top: 20, right: 20, zIndex: 10 }}>
+                <ThemeToggleButton />
+                </Box>
+
+
                 <Box sx={{ textAlign: 'center', mb: 8 }}>
                         <Box>
                                 <Typography 


### PR DESCRIPTION
Added a a theme toggle button to allow users to switch between light and dark modes, enhancing user preference and accessibility.

Before: 
<img width="1778" height="790" alt="image" src="https://github.com/user-attachments/assets/72ede4df-61ae-4feb-9747-d32c3d540512" />

After:
<img width="1907" height="792" alt="image" src="https://github.com/user-attachments/assets/9d19fccb-d432-4ea3-ae0d-93168964a215" />
<img width="1904" height="810" alt="image" src="https://github.com/user-attachments/assets/e4f5b622-9efb-4f4e-9397-f24854464cc7" />
<img width="1888" height="792" alt="image" src="https://github.com/user-attachments/assets/45905a96-37be-4469-a6dd-9b4923936e63" />

@braydenidzenga please merge it and add suitable Hacktoberfest2025 tags
