### PR TITLE
fix: remove unintended /* comment from homepage (closes #45)

### DIFF
--- a/frontend/src/pages/landingpage.jsx
+++ b/frontend/src/pages/landingpage.jsx
@@ -318,7 +318,6 @@ export default function Landing() {
                 </Box>
             </Container>
 
-            /*
             {/* Benefits Section */}
 
             {/* Final CTA Section */}


### PR DESCRIPTION
## Description

This PR removes an unintended /* comment artifact that was present on the homepage. The comment didn’t serve any purpose and could cause readability or linting issues in the code.

## Changes Made

- Removed stray /* comment from the homepage file.

- Verified that the homepage renders properly after cleanup.

## Purpose

Improves code clarity and maintains clean, readable source files.

Closes #45