### PR TITLE
Enhancement/add password visibility toggle

### DIFF
--- a/frontend/src/pages/login.jsx
+++ b/frontend/src/pages/login.jsx
@@ -5,7 +5,10 @@ import {
     TextField,
     Typography,
     Paper,
+    IconButton,
+    InputAdornment,
 } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
 import { LoadingButton } from "@mui/lab";
 import { useNavigate } from "react-router-dom";
 
@@ -14,6 +17,7 @@ import { API_URL } from "../config";
 export default function Login() {
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
+    const [showPassword, setShowPassword] = useState(false);
     const [loading, setLoading] = useState(false);
     const [errors, setErrors] = useState("");
     const navigate = useNavigate();
@@ -80,12 +84,25 @@ export default function Login() {
 
                     <TextField
                         label="Password"
-                        type="password"
+                        type={showPassword ? "text" : "password"}
                         variant="outlined"
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         required
                         fullWidth
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        onClick={() => setShowPassword(!showPassword)}
+                                        edge="end"
+                                        aria-label="toggle password visibility"
+                                    >
+                                        {showPassword ? <VisibilityOff /> : <Visibility />}
+                                    </IconButton>
+                                </InputAdornment>
+                            ),
+                        }}
                     />
 
                     <LoadingButton

--- a/frontend/src/pages/signup.jsx
+++ b/frontend/src/pages/signup.jsx
@@ -5,7 +5,10 @@ import {
     TextField,
     Typography,
     Paper,
+    IconButton,
+    InputAdornment,
 } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
 import { LoadingButton } from "@mui/lab";
 import { useNavigate } from "react-router-dom";
 
@@ -16,6 +19,8 @@ export default function Signup() {
     const [name, setName] = useState("");
     const [password, setPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirmPassword, setShowConfirmPassword] = useState(false);
     const [loading, setLoading] = useState(false);
     const [errors, setErrors] = useState("");
     const navigate = useNavigate();
@@ -70,8 +75,6 @@ export default function Signup() {
                         </Typography>
                     )}
 
-
-
                     <TextField
                         label="Name"
                         type="text"
@@ -94,22 +97,48 @@ export default function Signup() {
 
                     <TextField
                         label="Password"
-                        type="password"
+                        type={showPassword ? "text" : "password"}
                         variant="outlined"
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         required
                         fullWidth
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        onClick={() => setShowPassword(!showPassword)}
+                                        edge="end"
+                                        aria-label="toggle password visibility"
+                                    >
+                                        {showPassword ? <VisibilityOff /> : <Visibility />}
+                                    </IconButton>
+                                </InputAdornment>
+                            ),
+                        }}
                     />
 
                     <TextField
-                        label="Confirm password"
-                        type="password"
+                        label="Confirm Password"
+                        type={showConfirmPassword ? "text" : "password"}
                         variant="outlined"
                         value={confirmPassword}
                         onChange={(e) => setConfirmPassword(e.target.value)}
                         required
                         fullWidth
+                        InputProps={{
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                                        edge="end"
+                                        aria-label="toggle confirm password visibility"
+                                    >
+                                        {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                                    </IconButton>
+                                </InputAdornment>
+                            ),
+                        }}
                     />
 
                     <LoadingButton
@@ -121,7 +150,6 @@ export default function Signup() {
                     >
                         Sign Up
                     </LoadingButton>
-
                 </Box>
             </Paper>
         </Container>


### PR DESCRIPTION
## Description:

This PR improves the user experience on the Signup and Login pages by adding an eye icon to the password fields. Users can now toggle the visibility of their passwords while typing, reducing input errors and making the forms more user-friendly.

## Changes Made:

- Added showPassword state and visibility toggle to the Password field on both pages.

- Added showConfirmPassword state and visibility toggle to the Confirm Password field on the Signup page.

- Used MUI IconButton with Visibility / VisibilityOff icons to handle toggling.

- No other functionality or styling was altered.

Closes #47 