### PR TITLE
Fix: 67 Prevent Redirect to `/` & Multiple Toasts on Page Create and Delete

### DIFF
--- a/frontend/src/components/ui/ThemeContext.jsx
+++ b/frontend/src/components/ui/ThemeContext.jsx
@@ -102,11 +102,6 @@ export function ThemeContextProvider({ children }) {
 export function ThemeToggleButton() {
     const { mode, toggleColorMode } = useThemeContext();
 
-    const theme = createTheme(getDesignTokens(mode));
-    const buttonColor = theme.palette.mode === 'dark' 
-        ? theme.palette.primary.light 
-        : theme.palette.primary.dark;
-
     return (
         <IconButton
             sx={{

--- a/frontend/src/components/ui/newPagePopup.jsx
+++ b/frontend/src/components/ui/newPagePopup.jsx
@@ -18,7 +18,7 @@ import { Add as AddIcon } from '@mui/icons-material';
 import {API_URL} from "../../config";
 import { showToast } from "../../utils/toast";
 
-export default function NewPagePopup({ open, onClose }) {
+export default function NewPagePopup({ open, onClose, onPageCreated }) {
     const [name, setName] = useState("");
     const [loading, setLoading] = useState(false);
     const navigate = useNavigate();
@@ -62,7 +62,7 @@ export default function NewPagePopup({ open, onClose }) {
                 showToast.success(`Page "${name}" created successfully!`);
                 setName("");
                 onClose();
-                window.location.reload();
+                if (onPageCreated) onPageCreated();
             } else {
                 const data = await res.json();
                 showToast.error(data.message || "Failed to create page");

--- a/frontend/src/components/ui/pageView.jsx
+++ b/frontend/src/components/ui/pageView.jsx
@@ -25,7 +25,7 @@ const normalizePage = (page) => ({
     content: page?.pageData,
 });
 
-export default function PageView({ page }) {
+export default function PageView({ page, onPageDeleted }) {
     const normalizedPage = normalizePage(page);
     const [content, setContent] = useState("");
     const [editing, setEditing] = useState(true);
@@ -34,6 +34,7 @@ export default function PageView({ page }) {
     const textareaRef = useRef(null);
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+    
 
     useEffect(() => {
         if (!normalizedPage.id) return;
@@ -118,7 +119,8 @@ export default function PageView({ page }) {
                 showToast.error("Failed to delete page");
             } else {
                 showToast.success("Page deleted successfully");
-                window.location.reload();
+                if (onPageDeleted) onPageDeleted();
+                setContent("");
             }
         } catch (err) {
             console.error(err);

--- a/frontend/src/components/ui/provider.jsx
+++ b/frontend/src/components/ui/provider.jsx
@@ -1,22 +1,5 @@
 import * as React from "react";
-import { ThemeProvider, createTheme } from "@mui/material/styles";
-import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeContextProvider } from "./ThemeContext";
-
-const theme = createTheme({
-    palette: {
-        mode: "light",
-        primary: {
-            main: "#1976d2",
-        },
-        secondary: {
-            main: "#9c27b0",
-        },
-    },
-    shape: {
-        borderRadius: 12,
-    },
-});
 
 export const UIProvider = ({ children }) => {
     return (

--- a/frontend/src/components/ui/sidebar.jsx
+++ b/frontend/src/components/ui/sidebar.jsx
@@ -20,7 +20,7 @@ import {
 import { API_URL } from "../../config";
 import { showToast } from "../../utils/toast";
 
-export default function Sidebar({ token, onSelectPage }) {
+export default function Sidebar({ token, onSelectPage, refreshTrigger }) {
     const [ownedPages, setOwnedPages] = useState([]);
     const [sharedPages, setSharedPages] = useState([]);
     const [loading, setLoading] = useState(true);
@@ -48,7 +48,7 @@ export default function Sidebar({ token, onSelectPage }) {
         };
 
         fetchPages();
-    }, [token]);
+    }, [token, refreshTrigger]);
 
     // Normalize page object for frontend
     const normalizePage = (page) => ({

--- a/frontend/src/pages/home.jsx
+++ b/frontend/src/pages/home.jsx
@@ -14,7 +14,7 @@ import {
     TrendingUp as TrendingIcon 
 } from '@mui/icons-material';
 
-export default function Home() {
+export default function Home(token, refreshTrigger) {
     const navigate = useNavigate();
     const [selectedPage, setSelectedPage] = useState(null);
     const [name, setName] = useState("");
@@ -47,7 +47,7 @@ export default function Home() {
         }
 
         getUser();
-    });
+    },[navigate, token, refreshTrigger]);
 
 
 
@@ -223,7 +223,10 @@ export default function Home() {
                     }}
                 >
                     {selectedPage ? (
-                        <PageView page={selectedPage} />
+                        <PageView 
+                            page={selectedPage} 
+                            onPageDeleted={()=>{setSelectedPage(null);setSidebarRefresh(prev => prev+1)}}
+                        />
                     ) : (
                         <WelcomeScreen />
                     )}

--- a/frontend/src/pages/home.jsx
+++ b/frontend/src/pages/home.jsx
@@ -4,7 +4,7 @@ import Sidebar from "../components/ui/sidebar";
 import Navbar from "../components/ui/Navbar";
 import PageView from "../components/ui/pageView";
 import NewPagePopup from "../components/ui/newPagePopup";
-import { Typography, Box, Paper, Card, CardContent, useTheme, useMediaQuery } from "@mui/material";
+import { Typography, Box, Paper, Card, CardContent, useTheme } from "@mui/material";
 import { useEffect } from "react";
 import { API_URL } from "../config";
 import { showToast } from "../utils/toast";
@@ -21,7 +21,6 @@ export default function Home() {
     const [newPagePopupOpen, setNewPagePopupOpen] = useState(false);
     const theme = useTheme();
     const [sidebarRefresh, setSidebarRefresh] = useState(0);
-    const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
 
     useEffect(() => {
@@ -51,11 +50,6 @@ export default function Home() {
     });
 
 
-    const onLogout = () => {
-        localStorage.removeItem("token");
-        showToast.info("Logged out successfully");
-        navigate("/");
-    };
 
     const onCreatePage = () => {
         setNewPagePopupOpen(true);

--- a/frontend/src/pages/home.jsx
+++ b/frontend/src/pages/home.jsx
@@ -20,7 +20,9 @@ export default function Home() {
     const [name, setName] = useState("");
     const [newPagePopupOpen, setNewPagePopupOpen] = useState(false);
     const theme = useTheme();
+    const [sidebarRefresh, setSidebarRefresh] = useState(0);
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
 
     useEffect(() => {
         const token = localStorage.getItem("token");
@@ -212,6 +214,7 @@ export default function Home() {
                 <Sidebar
                     token={localStorage.getItem("token")}
                     onSelectPage={onSelectPage}
+                    refreshTrigger={sidebarRefresh}
                 />
 
                 <Box 
@@ -236,6 +239,7 @@ export default function Home() {
             <NewPagePopup 
                 open={newPagePopupOpen} 
                 onClose={() => setNewPagePopupOpen(false)} 
+                onPageCreated={() => setSidebarRefresh(prev => prev + 1)}
             />
         </Box>
     );

--- a/frontend/src/pages/landingpage.jsx
+++ b/frontend/src/pages/landingpage.jsx
@@ -16,12 +16,10 @@ import {
 } from "@mui/material";
 import { 
     Edit as EditIcon,
-    Group as GroupIcon,
     Folder as FolderIcon,
     Speed as SpeedIcon,
     Security as SecurityIcon,
     CloudSync as CloudIcon,
-    Star as StarIcon,
     GitHub as GitHubIcon
 } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
@@ -76,27 +74,6 @@ export default function Landing() {
             icon: <CloudIcon sx={{ fontSize: 40, color: 'primary.main' }} />,
             title: "Cloud Sync",
             description: "Access your notes anywhere, anytime. Your data syncs seamlessly across all your devices."
-        }
-    ];
-
-    const testimonials = [
-        {
-            name: "Alex Chen",
-            role: "Software Developer",
-            content: "ZettaNote has transformed how our team collaborates on documentation. Real-time editing are game-changers.",
-            rating: 5
-        },
-        {
-            name: "Sarah Johnson",
-            role: "Product Manager",
-            content: "Finally, a note-taking app that doesn't get in the way. Clean, fast, and exactly what we needed for our project planning.",
-            rating: 5
-        },
-        {
-            name: "Mike Rodriguez",
-            role: "Tech Lead",
-            content: "The open-source nature of ZettaNote gives us confidence in our data. Plus, the collaboration features are top-notch.",
-            rating: 5
         }
     ];
 


### PR DESCRIPTION
# Fix: Prevent Redirect to `/` & Multiple Toasts on Page Create & Delete

## Description

fixes: #67

This PR addresses the issue where creating a new page in the `NewPagePopup` resulted in:

- Two different toasts appearing simultaneously.
- Automatic redirection to `/` even though the page was successfully created.

The fix ensures that:

- Only a single success toast is shown.
- The user is **not redirected** after creating a page.
- The sidebar automatically refreshes to include the newly created page.

## Screenshots

Before:
<img width="1920" height="658" alt="Screenshot (8)" src="https://github.com/user-attachments/assets/cb054b81-2c66-42a3-8fdd-17a180a921fa" />

* Multiple toasts and redirect to `/` after creating a page.

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/050dd51c-e874-4b07-837b-1c5b23951bbb" />

* Single success toast.
* No redirection.
* Sidebar updates automatically with the new page.
