### PR TITLE
Fixed offcenter dot for Markdown bullet

### DIFF
--- a/frontend/src/components/dashboard/Note.jsx
+++ b/frontend/src/components/dashboard/Note.jsx
@@ -463,7 +463,7 @@ const Note = ({ activePage, onContentChange, content = '', onSave }) => {
       )
       .replace(
         /^- (.*$)/gm,
-        '<li class="flex items-start gap-2 my-1"><span class="text-primary mt-1">•</span> $1</li>'
+        '<li class="flex items-start gap-2 my-1"><span class="text-primary">•</span> $1</li>'
       )
       .replace(/^\d+\. (.*$)/gm, '<li class="flex items-start gap-2 my-1 ml-4">$1</li>')
 


### PR DESCRIPTION
## 📋 Description

This pull request fixes a visual alignment issue in the **Markdown renderer**.  
Specifically, in `note.jsx` at **line 466**, the bullet point element  
`<span class="text-primary">•</span> $1</li>` previously included the `mt-1` class,  
which caused the bullet dot to appear slightly off-center.  

The `mt-1` class was removed to correctly align the bullet points with the corresponding text content.

---

## 🔗 Related Issue

NONE

---

## 🧩 Type of Change

- [x]  Bug fix : visual alignment correction for Markdown bullet points

---

## 🧪 How Has This Been Tested?

- Verified rendering of Markdown lists in the note editor and viewer.  
- Confirmed bullet points are now perfectly centered vertically relative to text.  
- Checked both light and dark mode for consistency.

---

## 📸 Screenshots (if applicable)
**Before:**
<img width="375" height="137" alt="before" src="https://github.com/user-attachments/assets/d1ae853b-6690-4cfc-990b-e8f7b11fc448" />
**After:**
<img width="558" height="274" alt="after" src="https://github.com/user-attachments/assets/dfb845b0-efd7-4efa-bfca-21f102c4f4c0" />

---

