### PR TITLE
Fix: User Adding themself in shared users of a page  

### DIFF
--- a/backend/src/constants/messages.js
+++ b/backend/src/constants/messages.js
@@ -29,6 +29,7 @@ export const MESSAGES = {
     ACCESS_DENIED: 'You do not have access to this page',
     SHARED: 'Page shared successfully',
     UNSHARED: 'Page unshared successfully',
+    SHARE_SELF_NOT_ALLOWED:'You cannot share page with yourself'
   },
 
   // Admin Messages

--- a/backend/src/controllers/page.controller.js
+++ b/backend/src/controllers/page.controller.js
@@ -471,7 +471,7 @@ export const sharePage = async (req) => {
     // Validate input
     const sharePageSchema = z.object({
       pageId: z.string().min(1, 'Page ID is required'),
-      email: z.string().email('Invalid email address'),
+      email: z.email('Invalid email address'),
     });
     const parseResult = sharePageSchema.safeParse(req.body);
     if (!parseResult.success) {
@@ -507,6 +507,14 @@ export const sharePage = async (req) => {
       return {
         resStatus: STATUS_CODES.FORBIDDEN,
         resMessage: { message: MESSAGES.PAGE.ACCESS_DENIED },
+      };
+    }
+
+    // Check if user shares page to self
+    if (user.email === userEmail.toLowerCase()) {
+      return {
+        resStatus: STATUS_CODES.BAD_REQUEST,
+        resMessage: { message: MESSAGES.PAGE.SHARE_SELF_NOT_ALLOWED },
       };
     }
 

--- a/frontend/src/components/dashboard/TopBar.jsx
+++ b/frontend/src/components/dashboard/TopBar.jsx
@@ -33,8 +33,8 @@ const TopBar = ({ activePage, onSave, lastSaved, isLoading, onToggleSidebar, isS
   const [lastFailedEmail, setLastFailedEmail] = useState('');
   const [isFetchingSharedUsers, setIsFetchingSharedUsers] = useState(false);
   const navigate = useNavigate();
-  const { setuser } = useContext(authContext);
-
+  const { user, setuser } = useContext(authContext);
+  
   const handleUnauthorized = (error) => {
     if (error.response && error.response.status === 401) {
       setuser(null);
@@ -193,6 +193,11 @@ const TopBar = ({ activePage, onSave, lastSaved, isLoading, onToggleSidebar, isS
   const inviteUser = async () => {
     if (!newUserEmail.trim() || !activePage?.id) {
       toast.error('Please select a page and enter an email address');
+      return;
+    }
+
+    if (newUserEmail.trim().toLowerCase() === user?.email) {
+      toast.error('You cannot invite yourself');
       return;
     }
 


### PR DESCRIPTION
## 📋 Description
Fixes a Bug where the user is able to shares his page to himself 
- Added a check condition on Frontend 
- Added a check condition on Backend

At this Part :
<img width="864" height="404" alt="image" src="https://github.com/user-attachments/assets/742802e2-7584-4cf4-b04d-3c737c61553f" />

Other changes : 
- From :
email: z.string().email('Invalid email address'),
- To :
email: z.email('Invalid email address'),

Reason :
- Was marked as // fixed @ deprecated — Uses z.email() instead.

---

## 🔗 Related Issue

Fixes #152

---

## 🧩 Type of Change

- [✅ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation update
- [ ] ✅ Test addition or update
- [ ] ⚙️ Other (please describe):

---

## 🧪 How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- checked changing lowerCase to upperCase
- fixed case sensitive issue on both frontend and backend

---

## 📸 Screenshots (if applicable)
when user try to share page to himself toast appears : 
<img width="1418" height="559" alt="image" src="https://github.com/user-attachments/assets/a11d00a9-e48a-4d16-ad94-381c7024394b" />


---

## 🧠 Additional Context

Add any other relevant information or context here.
