### PR TITLE
Resolved [BUG] while making new note, the popup for filling name of the note opens up in the side section,  issue no. #164

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.jsx
+++ b/frontend/src/components/dashboard/Sidebar.jsx
@@ -685,18 +685,22 @@ const Sidebar = ({ onPageSelect, selectedPageId, isOpen, onClose }) => {
                   <div>
                     <p className="text-xs text-base-content/60 mb-2">Quick suggestions:</p>
                     <div className="flex flex-wrap gap-2">
-                      {['Meeting Notes', 'Ideas', 'To-Do List', 'Project Plan', 'Daily Journal'].map(
-                        (suggestion) => (
-                          <button
-                            key={suggestion}
-                            onClick={() => setNewPageName(suggestion)}
-                            className="btn btn-xs btn-ghost btn-outline hover:btn-primary"
-                            disabled={isCreating}
-                          >
-                            {suggestion}
-                          </button>
-                        )
-                      )}
+                      {[
+                        'Meeting Notes',
+                        'Ideas',
+                        'To-Do List',
+                        'Project Plan',
+                        'Daily Journal',
+                      ].map((suggestion) => (
+                        <button
+                          key={suggestion}
+                          onClick={() => setNewPageName(suggestion)}
+                          className="btn btn-xs btn-ghost btn-outline hover:btn-primary"
+                          disabled={isCreating}
+                        >
+                          {suggestion}
+                        </button>
+                      ))}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Resolved Issue: #164 
## 📋 Description

Please provide a clear and concise description of what this pull request does.
while making new note, the popup for filling name of the note was opening up in the side section, this PR changes that behaviour and makes it open in the center of the screen instead
---

## 🔗 Related Issue
Fixes #164 
---

## 🧩 Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation update
- [ ] ✅ Test addition or update
- [ ] ⚙️ Other (please describe):

---

## 🧪 How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Tested by running the the frontend server; did not setup any env or smth just removed auth on dashboard route to test it temperarilly(which is untouched in this commit btw, it was just changed locally)
---

## 📸 Screenshots (if applicable)

<img width="1912" height="1241" alt="image" src="https://github.com/user-attachments/assets/4f24ffb1-3ff6-4bf5-8b2e-93056f1a10b7" />

---

## 🧠 Additional Context

Add any other relevant information or context here.
