### PR TITLE
feat(editor): add floating inline toolbar to Note editor

### DIFF
--- a/backend/src/config/cors.js
+++ b/backend/src/config/cors.js
@@ -8,26 +8,34 @@ import logger from '../utils/logger.js';
  */
 export const configureCors = () => {
   const { allowedOrigins } = config.cors;
+  // Normalize allowed origins for robust matching
+  const normalizedAllowed = allowedOrigins.map((o) => o.replace(/\/$/, '').toLowerCase());
+
+  // Helpful startup log showing which origins are accepted
+  logger.info('CORS allowed origins:', normalizedAllowed.join(', '));
 
   return cors({
     origin: function (origin, callback) {
-      // Allow requests with no origin (mobile apps, Postman, curl, etc.)
+      // Allow requests with no origin (mobile apps, Postman, curl, server-to-server)
       if (!origin) {
         return callback(null, true);
       }
 
-      // Check if origin is in the allowed list
-      if (allowedOrigins.includes(origin)) {
+      const normalizedOrigin = origin.replace(/\/$/, '').toLowerCase();
+
+      if (normalizedAllowed.includes(normalizedOrigin)) {
         return callback(null, true);
-      } else {
-        // Log rejected origin for debugging
-        logger.warn('CORS rejected origin:', origin);
-        return callback(new Error('Not allowed by CORS'), false);
       }
+
+      // Helpful debug log when rejecting
+      logger.warn('CORS rejected origin:', origin);
+      return callback(new Error('Not allowed by CORS'), false);
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization', 'Cookie'],
+    preflightContinue: false,
+    optionsSuccessStatus: 204,
   });
 };
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "frontend_v2",
-  "version": "0.0.0",
+  "name": "zettanote-frontend",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend_v2",
-      "version": "0.0.0",
+      "name": "zettanote-frontend",
+      "version": "4.2.0",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tailwindcss/vite": "^4.1.14",


### PR DESCRIPTION
## 📋 Description  
This pull request fixes the position of the **editor toolbar** so that it stays visible while scrolling.  

Previously, users had to scroll back to the top to access formatting options like **Bold**, **Italic**, **Add Table**, or **Insert Image** when editing long notes.  
Now, the toolbar remains fixed, making editing smoother and faster without interrupting the writing flow.  

---

## 🔗 Related Issue  
Fixes #181  

---

## 🧩 Type of Change  
- [x] 🚀 New feature  
- [ ] 🐛 UI/UX improvement  

---

## 🧪 How Has This Been Tested?  
- Checked that the toolbar stays visible during scroll on both short and long notes.  
- Verified that all toolbar buttons still work properly.  
- Tested on different screen sizes to ensure it doesn’t overlap content.  

---

## 📸 Screenshots (if applicable)  
<img width="1893" height="769" alt="image" src="https://github.com/user-attachments/assets/e30ab76d-35f5-4181-96c5-75726f32bd5c" />

---

## 🧠 Additional Context  
This update improves the **editing experience** by reducing the need to scroll up repeatedly.  
It keeps all essential formatting tools easily accessible, similar to modern editors like **Notion** or **Obsidian**.  