### PR TITLE
Adding Ability To Select Custom Table Dimensions on Clicking "Add Table" Button.

### DIFF
--- a/backend/src/config/cors.js
+++ b/backend/src/config/cors.js
@@ -8,26 +8,34 @@ import logger from '../utils/logger.js';
  */
 export const configureCors = () => {
   const { allowedOrigins } = config.cors;
+  // Normalize allowed origins for robust matching
+  const normalizedAllowed = allowedOrigins.map((o) => o.replace(/\/$/, '').toLowerCase());
+
+  // Helpful startup log showing which origins are accepted
+  logger.info('CORS allowed origins:', normalizedAllowed.join(', '));
 
   return cors({
     origin: function (origin, callback) {
-      // Allow requests with no origin (mobile apps, Postman, curl, etc.)
+      // Allow requests with no origin (mobile apps, Postman, curl, server-to-server)
       if (!origin) {
         return callback(null, true);
       }
 
-      // Check if origin is in the allowed list
-      if (allowedOrigins.includes(origin)) {
+      const normalizedOrigin = origin.replace(/\/$/, '').toLowerCase();
+
+      if (normalizedAllowed.includes(normalizedOrigin)) {
         return callback(null, true);
-      } else {
-        // Log rejected origin for debugging
-        logger.warn('CORS rejected origin:', origin);
-        return callback(new Error('Not allowed by CORS'), false);
       }
+
+      // Helpful debug log when rejecting
+      logger.warn('CORS rejected origin:', origin);
+      return callback(new Error('Not allowed by CORS'), false);
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization', 'Cookie'],
+    preflightContinue: false,
+    optionsSuccessStatus: 204,
   });
 };
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "frontend_v2",
-  "version": "0.0.0",
+  "name": "zettanote-frontend",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend_v2",
-      "version": "0.0.0",
+      "name": "zettanote-frontend",
+      "version": "4.2.0",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "@tailwindcss/vite": "^4.1.14",


### PR DESCRIPTION
## 📋 Description  
This pull request improves the **Add Table** feature by allowing users to choose the number of rows and columns before inserting a table.  

Previously, clicking **Add Table** always created a fixed 2×3 table, forcing users to manually edit the Markdown afterward.  
Now, a small input prompt appears where users can enter the desired number of rows and columns — and a properly formatted Markdown table is generated automatically.  

This makes table creation faster, more flexible, and user-friendly.  

---

## 🔗 Related Issue  
Fixes #182  

---

## 🧩 Type of Change  
- [x] 🚀 New feature  
- [ ] 🐛 UI improvement  

---

## 🧪 How Has This Been Tested?  
- Clicked the **Add Table** button and verified that an input prompt appears.  
- Entered various combinations of rows and columns to confirm correct table generation.  
- Checked that the generated Markdown renders properly in preview mode.  

---

## 📸 Screenshots (if applicable)  
<img width="1884" height="806" alt="image" src="https://github.com/user-attachments/assets/d3abf12b-9abd-42b5-99dd-5e3a624c4636" />

<img width="1892" height="808" alt="image" src="https://github.com/user-attachments/assets/50dcc092-4e18-4f2f-88ed-128e930a0960" />


---

## 🧠 Additional Context  
This feature gives users more control over table creation, reducing the need for manual Markdown editing and improving the overall writing experience.  
It brings the editor closer to the flexibility of modern Markdown tools like **Obsidian** and **Typora**.  
