### PR TITLE
Add the Frontend for Tasks

### DIFF
--- a/backend/src/controllers/page.controller.js
+++ b/backend/src/controllers/page.controller.js
@@ -676,7 +676,7 @@ export const publicShare = async (req) => {
       };
     }
 
-    const { pageId, allowDownload = false } = req.body;
+    const { pageId, allowDownload = false, isPublic = true, isRegenerate = true } = req.body;
 
     const page = await Page.findById(pageId);
 
@@ -695,26 +695,22 @@ export const publicShare = async (req) => {
       };
     }
 
-    // Check if already has public share ID - UPDATE THIS PART
-    if (page.publicShareId) {
-      // Update the existing share settings, including allowDownload
-      page.allowDownload = allowDownload;
-      await page.save();
-
-      return {
-        resStatus: STATUS_CODES.OK,
-        resMessage: {
-          message: 'Share settings updated',
-          publicShareId: page.publicShareId,
-          allowDownload: page.allowDownload,
-        },
-      };
+    if (!isPublic) {
+      page.publicShareId = '';
+      page.allowDownload = false;
     }
 
-    // Generate and save public share ID for new share
-    const uniqueShareId = uuidv4();
-    page.publicShareId = uniqueShareId;
-    page.allowDownload = allowDownload;
+    // Check if already has public share ID - UPDATE THIS PART
+    else if (!isRegenerate) {
+      // Update the existing share settings, including allowDownload
+      page.allowDownload = allowDownload;
+    } else {
+      // Generate and save public share ID for new share
+      const uniqueShareId = uuidv4();
+      page.publicShareId = uniqueShareId;
+      page.allowDownload = allowDownload;
+    }
+
     await page.save();
 
     return {

--- a/backend/src/models/Page.model.js
+++ b/backend/src/models/Page.model.js
@@ -33,7 +33,7 @@ const PageSchema = new mongoose.Schema({
     required: true,
     default: Date.now,
   },
-  allowDownload: { type: Boolean, default: true },
+  allowDownload: { type: Boolean, default: false },
 });
 
 export default mongoose.model('Page', PageSchema);

--- a/frontend/src/components/dashboard/TopBar.jsx
+++ b/frontend/src/components/dashboard/TopBar.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useEffect, useRef } from 'react';
+import { useContext, useState } from 'react';
 import {
   FiShare2,
   FiCopy,
@@ -46,36 +46,73 @@ const TopBar = ({ activePage, onSave, lastSaved, isLoading }) => {
     }
     return false;
   };
-  const [shareSettings, setShareSettings] = useState({
-    isPublic: true,
+  const [currentShareSetting, setCurrentShareSetting] = useState({
+    isPublic: null,
     allowComments: false,
-    allowDownload: true,
+    allowDownload: null,
     expiresAt: null,
   });
 
-  // Track previous allowDownload to detect deselect (true -> false)
-  const prevAllowDownloadRef = useRef(shareSettings.allowDownload);
+  const [previousShareSettings, setPreviousShareSettings] = useState({
+    isPublic: null,
+    allowComments: false,
+    allowDownload: null,
+    expiresAt: null,
+  });
 
-  // Auto-regenerate link when the user deselects the "Allow Download" option.
-  // Guards: don't run on initial render and don't trigger while a generation
-  // is already in progress.
-  useEffect(() => {
-    const prev = prevAllowDownloadRef.current;
-    const current = shareSettings.allowDownload;
+  const getStatus = async () => {
+    const response = await axios.post(
+      `${VITE_API_URL}/api/pages/getpage`,
+      { pageId: activePage.id },
+      { withCredentials: true }
+    );
 
-    // Only act when toggled from true -> false
-    if (prev === true && current === false) {
-      // If we already have a public link, regenerate it to apply new policy.
-      // Otherwise just generate one.
-      if (!isGeneratingLink) {
-        if (shareableLink) regenerateLink();
-        else generateShareableLink();
-      }
+    const data = response.data.Page;
+
+    setPreviousShareSettings({
+      ...currentShareSetting,
+      isPublic: !!data.publicShareId,
+      allowDownload: data.allowDownload,
+    });
+    setCurrentShareSetting({
+      ...currentShareSetting,
+      isPublic: !!data.publicShareId,
+      allowDownload: data.allowDownload,
+    });
+
+    if (data.publicShareId) {
+      setShareableLink(`${window.location.origin}/public/${data.publicShareId}`);
+    } else {
+      setShareableLink('');
+    }
+  };
+
+  const handleSave = async () => {
+    if (
+      currentShareSetting.isPublic != previousShareSettings.isPublic &&
+      currentShareSetting.isPublic
+    ) {
+      generateShareableLink();
+      return;
     }
 
-    prevAllowDownloadRef.current = current;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shareSettings.allowDownload]);
+    try {
+      await axios.post(
+        `${VITE_API_URL}/api/pages/publicshare`,
+        {
+          pageId: activePage.id,
+          allowDownload: currentShareSetting.allowDownload,
+          isPublic: currentShareSetting.isPublic,
+          isRegenerate: currentShareSetting.isPublic ? false : true,
+        },
+        { withCredentials: true }
+      );
+      toast.success('Saved Successfully');
+      // eslint-disable-next-line no-unused-vars
+    } catch (error) {
+      toast.error('Error Saving');
+    }
+  };
 
   const generateShareableLink = async () => {
     if (!activePage?.id) return;
@@ -86,17 +123,21 @@ const TopBar = ({ activePage, onSave, lastSaved, isLoading }) => {
         `${VITE_API_URL}/api/pages/publicshare`,
         {
           pageId: activePage.id,
-          allowDownload: shareSettings?.allowDownload ?? true, // ✅ added line
-          isPublic: shareSettings?.isPublic ?? true, // optional
-          allowComments: shareSettings?.allowComments ?? false, // optional
-          expiresAt: shareSettings?.expiresAt ?? null, // optional
+          allowDownload: false,
+          isPublic: true,
+          allowComments: currentShareSetting?.allowComments ?? false, // optional
+          expiresAt: currentShareSetting?.expiresAt ?? null, // optional
         },
         { withCredentials: true }
       );
 
       if (response.status === 200 && response.data) {
         const publicLink = `${window.location.origin}/public/${response.data.publicShareId}`;
+
+        setPreviousShareSettings({ ...currentShareSetting, isPublic: true, allowDownload: false });
+        setCurrentShareSetting({ ...currentShareSetting, isPublic: true, allowDownload: false });
         setShareableLink(publicLink);
+        copyToClipboard(publicLink);
 
         if (response.data.message === 'Already Shared') {
           toast.success('🔗 Public link retrieved successfully!');
@@ -211,7 +252,7 @@ const TopBar = ({ activePage, onSave, lastSaved, isLoading }) => {
 
   const handleShare = () => {
     setShowShareModal(true);
-    generateShareableLink();
+    getStatus();
     fetchSharedUsers();
   };
 
@@ -491,9 +532,12 @@ const TopBar = ({ activePage, onSave, lastSaved, isLoading }) => {
                         <input
                           type="checkbox"
                           className="checkbox checkbox-primary"
-                          checked={shareSettings.isPublic}
+                          checked={currentShareSetting.isPublic}
                           onChange={(e) =>
-                            setShareSettings({ ...shareSettings, isPublic: e.target.checked })
+                            setCurrentShareSetting({
+                              ...currentShareSetting,
+                              isPublic: e.target.checked,
+                            })
                           }
                         />
                         <div className="flex items-center gap-2">
@@ -511,9 +555,12 @@ const TopBar = ({ activePage, onSave, lastSaved, isLoading }) => {
                         <input
                           type="checkbox"
                           className="checkbox checkbox-secondary"
-                          checked={shareSettings.allowDownload}
+                          checked={currentShareSetting.allowDownload}
                           onChange={(e) =>
-                            setShareSettings({ ...shareSettings, allowDownload: e.target.checked })
+                            setCurrentShareSetting({
+                              ...currentShareSetting,
+                              allowDownload: e.target.checked,
+                            })
                           }
                         />
                         <div className="flex items-center gap-2">
@@ -692,16 +739,12 @@ const TopBar = ({ activePage, onSave, lastSaved, isLoading }) => {
                 </button>
                 <button
                   onClick={() => {
-                    if (shareableLink) {
-                      copyToClipboard(shareableLink);
-                    }
+                    handleSave();
                     setShowShareModal(false);
                   }}
                   className="btn btn-primary gap-2 rounded-xl shadow-lg shadow-primary/25 hover:scale-105 transition-all"
-                  disabled={!shareableLink}
                 >
-                  <FiCopy className="w-4 h-4" />
-                  {shareableLink ? 'Copy Link & Close' : 'Close'}
+                  Save
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Description

This pull request introduces the **Reminders System** feature to the dashboard frontend.  
It adds a **floating reminders button**, an interactive **slide-in sidebar**, and a full **reminder management interface** with CRUD operations and visual feedback.

---

## Related Issue

Fixes https://github.com/braydenidzenga/ZettaNote/issues/143

---

## Type of Change

- [x] New feature  
- [x] Code refactor  
- [ ] Documentation update  

---

## How Has This Been Tested?

- Verified UI rendering on both desktop and mobile layouts.  
- Tested all CRUD operations with live API responses:
  - Fetch reminders (`GET /api/task/getAllTasks`)  
  - Create new reminder (`POST /api/task/createTask`)  
  - Toggle completion (`PUT /api/task/toggleCompletion`)  
  - Delete reminder (`DELETE /api/task/deleteTask`)  
- Ensured correct time formatting and visual states for overdue/due soon/completed tasks.  
- Confirmed proper loading and error handling through toast notifications.  

---

## Screenshots (if applicable)
<img width="1512" height="982" alt="Screenshot 2025-10-21 at 5 00 11 PM" src="https://github.com/user-attachments/assets/6922e7cb-c088-4b20-8d20-b3b365cc1538" />
---

## Additional Context

### Feature Overview: Reminders System

#### What We Added

**Floating Reminders Button**
- Positioned at bottom-right of dashboard  
- Animated bell icon with hover effects  
- Opens reminders sidebar when clicked  

**Sliding Reminders Sidebar**
- Smooth slide-in animation from right  
- Full-height overlay with backdrop blur  
- Complete CRUD operations for reminders  

**Reminder Management Interface**
- Add new reminders (title, description, due date/time)  
- View reminders with visual status indicators  
- Toggle completion with instant feedback  
- Delete reminders  
- Smart time formatting (e.g., “2d 5h left”, “3h 15m overdue”)  

**Visual Features**
- Color-coded reminders:  
  - Green for completed  
  - Red for overdue  
  - Yellow for due soon  
- Strikethrough for completed tasks  
- Animated toggle buttons with pulse effects  
- Responsive layout for mobile and desktop  
- Toast notifications for success and error states  

---

### Backend API Endpoints Used

| Method | Endpoint | Purpose | Payload / Response |
|---------|-----------|----------|--------------------|
| GET | `/api/task/getAllTasks` | Fetch all reminders | Response: `{ Tasks: [...] }` |
| POST | `/api/task/createTask` | Create new reminder | `{ taskName, taskDescription, taskDeadline }` |
| PUT | `/api/task/toggleCompletion` | Toggle completion status | `{ taskId }` |
| DELETE | `/api/task/deleteTask` | Delete reminder | `{ taskId }` |
