### PR TITLE
📝 docs: fix command for creating default admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The frontend is built with:
 4. **Create default admin user**
    ```bash
    cd ZettaNote/backend
-   node createFirstAdmin.js
+   npm run create-admin
    ```
 
 ---


### PR DESCRIPTION
## 📋 Description
Hi,
While following the README for the manual initial setup, I noticed a small mistake: the command for creating the default admin user doesn’t work and throws an `Error: Cannot find module` because the file path in the command is incorrect.

When I checked the file location, I found that the script located at
`ZettaNote/backend/scripts/createFirstAdmin.js` instead of `ZettaNote/backend/createFirstAdmin.js`. The correct command is already provided in the `package.json` scripts section, which points to the proper location.

It looks like the README wasn’t updated after the script was moved.  This PR fixes the issue by correcting the command in the README.

---

## 🔗 Related Issue

Fixes # (issue number if applicable)

---

## 🧩 Type of Change

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 🧹 Code refactor
- [X] 📝 Documentation update
- [ ] ✅ Test addition or update
- [ ] ⚙️ Other (please describe):

---

## 🧪 How Has This Been Tested?

I reviewed the updated README and confirmed that the corrected command is accurate and free of typographical errors.

---

## 📸 Screenshots (if applicable)

**Error when you run the command in the README**

<img width="966" height="442" alt="error_creating_admin_user" src="https://github.com/user-attachments/assets/81e832e9-7007-40f2-b0f6-0aa25faf2a7e" />

---

## 🧠 Additional Context

Add any other relevant information or context here.
