### PR TITLE
perf(docker): copy only the source code to the building images

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,3 +1,11 @@
 node_modules
 .env
 .env.example
+.git
+.gitignore
+.DS_Store
+*.md
+Dockerfile
+.dockerignore
+eslint.config.js
+postman_collection_for_api_testing.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,11 +8,14 @@ RUN npm install -g pnpm
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./
 
-# Install dependencies (production only)
-RUN pnpm install --prod 
+# Install dependencies and clear cache
+RUN pnpm install --prod --frozen-lockfile && \
+    pnpm store prune
 
-# Copy application code
-COPY . .
+# Copy necessary application code
+COPY server.js ./
+COPY src ./src
+COPY scripts ./scripts
 
 # Environment variables (these will be overridden by Coolify)
 ENV NODE_ENV=production

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,1 +1,12 @@
 node_modules
+dist
+.env
+.env.example
+.git
+.gitignore
+.DS_Store
+*.md
+Dockerfile
+.dockerignore
+eslint.config.js
+package-lock.json

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,11 +10,14 @@ RUN npm install -g pnpm
 # Copy package files
 COPY package.json pnpm-lock.yaml ./
 
-# Install dependencies
-RUN pnpm install --frozen-lockfile
+# Install dependencies and clear cache
+RUN pnpm install --frozen-lockfile && \
+    pnpm store prune
 
-# Copy source code
-COPY . .
+# Copy necessary source code
+COPY index.html vite.config.js ./
+COPY public ./public
+COPY src ./src
 
 # Build argument for API URL
 ARG VITE_API_URL=http://localhost:4000


### PR DESCRIPTION
## 📋 Description

I’ve noticed that both Dockerfiles of the project copy everything inside its folder into the running images. To avoid this, I try to copy only the necessary files and also clear the pnpm cache. 

---

## 🔗 Related Issue

- None

---

## 🧩 Type of Change

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation update
- [ ] ✅ Test addition or update
- [x] ⚙️ Other (please describe): Optimize Dockerfile for the backend and frontend

---

## 🧪 How Has This Been Tested?

- `docker compose` able to build and run

Please describe the tests that you ran to verify your changes.

---

## 📸 Screenshots (if applicable)

- None
---

## 🧠 Additional Context

Feel free to discuss and please let me know if any required files in the runtime are missing and should be added to the image.
